### PR TITLE
Upgrade aiohttp and python-jwt packages

### DIFF
--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -1,4 +1,5 @@
-aiohttp==3.9.5
+aiohappyeyeballs==2.4.0
+aiohttp==3.10.5
 aiosignal==1.3.1
 annotated-types==0.7.0
 anyio==4.4.0
@@ -45,6 +46,7 @@ imageio-ffmpeg==0.5.1
 Jinja2==3.1.4
 jsonpatch==1.33
 jsonpointer==3.0.0
+jwcrypto==1.5.6
 jws==0.1.3
 langchain==0.2.11
 langchain-community==0.2.10
@@ -84,7 +86,7 @@ pyparsing==3.1.2
 Pyrebase4==4.8.0
 python-docx==1.1.2
 python-dotenv==1.0.1
-python-jwt==2.0.1
+python-jwt==4.1.0
 python-multipart==0.0.9
 python-pptx==0.6.23
 PyYAML==6.0.1


### PR DESCRIPTION
Known security vulnerabilities detected from Dependabot:
- Upgraded `aiohttp` from 3.9.5 to 3.10.5
- Upgraded `python-jwt` from 2.0.1 to 4.1.0